### PR TITLE
Added plugin for managing tracking cookies

### DIFF
--- a/librarian_analytics/config.ini
+++ b/librarian_analytics/config.ini
@@ -4,5 +4,12 @@ names =
     analytics
 
 [analytics]
+
 # Send collected analytics data every ``send_interval`` seconds
 send_interval = 86400
+
+# Cookie name for tracking cookie
+tracking_cookie_name = ca
+
+# Device ID file
+device_id_file = tmp/devce_id.key

--- a/librarian_analytics/data.py
+++ b/librarian_analytics/data.py
@@ -1,0 +1,44 @@
+import uuid
+
+import user_agents
+
+
+FIELD_SEPARATOR = '$'
+DESKTOP = 1
+PHONE = 2
+TABLET = 3
+OTHER = 0
+
+
+def generate_device_id():
+    return str(uuid.uuid4())
+
+
+def generate_user_id():
+    return uuid.uuid4().hex[:8]
+
+
+def characterize_agent(ua_string):
+    ua = user_agents.parse(ua_string)
+    if ua.is_pc:
+        return DESKTOP
+    elif ua.is_tablet:
+        return TABLET
+    elif ua.is_mobile:
+        return PHONE
+    return OTHER
+
+
+def serialize_cookie_data(*args):
+    return FIELD_SEPARATOR.join(str(a) for a in args)
+
+
+def deserialize_cookie_data(data):
+    try:
+        user_id, agent_type = data.split(FIELD_SEPARATOR)
+        agent_type = int(agent_type)
+        assert agent_type in [DESKTOP, TABLET, PHONE, OTHER], 'Invalid type?'
+        assert len(user_id) == 8, 'Invalid user ID?'
+        return user_id, agent_type
+    except (ValueError, TypeError):
+        return None

--- a/librarian_analytics/plugins.py
+++ b/librarian_analytics/plugins.py
@@ -47,7 +47,7 @@ def set_track_id(cookie_name):
         'agent_type': agent_type
     }
     cookie_data = data.serialize_cookie_data(user_id, agent_type)
-    response.set_cookie(cookie_name, cookie_data)
+    response.set_cookie(cookie_name, cookie_data, path='/')
 
 
 def tracking_id_cookie_plugin(supervisor):

--- a/librarian_analytics/plugins.py
+++ b/librarian_analytics/plugins.py
@@ -1,0 +1,66 @@
+import uuid
+import logging
+import functools
+
+from bottle import request, response
+
+from . import data
+
+
+EXPORTS = {
+    'tracking_id_cookie_plugin': {},
+}
+
+
+def prepare_device_id(path):
+    try:
+        with open(path, 'w') as f:
+            current_key = f.read()
+    except IOError:
+        current_key = ''
+    if not current_key:
+        # No key has been set yet
+        current_key = data.generate_device_id()
+        with open(path, 'w') as f:
+            f.write(current_key)
+    assert current_key != '', "'My dog ate it' is a poor excuse"
+    return current_key
+
+
+def set_track_id(cookie_name):
+    cookie_data = request.get_cookie(cookie_name)
+    if cookie_data:
+        # Cookie is already set, so we don't touch it
+        user_id, agent_type = data.deserialize_cookie_data(cookie_data)
+        request.tracking_info = {
+            'user_id': user_id,
+            'agent_type': agent_type
+        }
+        return
+
+    # Generate new cookie data
+    user_id = data.generate_user_id()
+    ua = request.headers.get('User-Agent')
+    agent_type = data.characterize_agent(ua)
+    request.tracking_info = {
+        'user_id': user_id,
+        'agent_type': agent_type
+    }
+    cookie_data = data.serialize_cookie_data(user_id, agent_type)
+    response.set_cookie(cookie_name, cookie_data)
+
+
+def tracking_id_cookie_plugin(supervisor):
+    tracking_cookie_name = supervisor.config['analytics.tracking_cookie_name']
+    device_id_file = supervisor.config['analytics.device_id_file']
+    device_id = prepare_device_id(device_id_file)
+
+    def plugin(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            request.device_id = device_id
+            set_track_id(tracking_cookie_name)
+            return fn(*args, **kwargs)
+        return wrapper
+
+    return plugin

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     long_description=read('README.rst'),
     install_requires=[
-        'ua-parser',
+        'user-agents',
         'librarian_core',
         'librarian_filemanager',
     ],


### PR DESCRIPTION
The plugin sets up the tracking cookie and device ID. Adds 2 new configuration options that define the tracking cookie name and path to device ID file (intention is to point it to monitoring device key). Separate data module provides functions for working with tracking-related stuff.