### PR TITLE
Use `librarian` database instead of `analytics`

### DIFF
--- a/librarian_analytics/config.ini
+++ b/librarian_analytics/config.ini
@@ -1,7 +1,8 @@
 [exports]
 
-databases =
-    analytics
+database = librarian
+
+database_sets = analytics
 
 migrations = migrations
 

--- a/librarian_analytics/routes.py
+++ b/librarian_analytics/routes.py
@@ -22,7 +22,7 @@ class AnalyticsData(RouteBase):
 
     def get(self):
         device_id_file = self.config['analytics.device_id_file']
-        db = exts.databases.analytics
+        db = exts.databases.librarian
         _, payload = get_payload(db, device_id_file, limit=None)
         filename = '{}.stats'.format(utcnow().isoformat())
         return send_file(StringIO(payload), filename, attachment=True)

--- a/librarian_analytics/tasks.py
+++ b/librarian_analytics/tasks.py
@@ -13,7 +13,7 @@ from .data import StatBitStream
 
 def store_data(data):
     data['timestamp'] = timestamp = utcnow()
-    helpers.save_stats(exts.databases.analytics, {
+    helpers.save_stats(exts.databases.librarian, {
         'time': timestamp,
         'payload': StatBitStream.to_bytes([data])
     })
@@ -52,7 +52,7 @@ class SendAnalytics(Task):
         # preliminary tests passed, attempt report sending
         device_id_file = exts.config['analytics.device_id_file']
         throttle = exts.config['analytics.throttle']
-        db = exts.databases.analytics
+        db = exts.databases.librarian
         ids, payload = helpers.get_payload(db, device_id_file, throttle)
         if not ids:
             # there are no unsent analytics stats, abort
@@ -74,7 +74,7 @@ class CleanupAnalytics(Task):
         return exts.config['analytics.cleanup_interval']
 
     def run(self):
-        db = exts.databases.analytics
+        db = exts.databases.librarian
         max_records = exts.config['analytics.max_records']
         rowcount = helpers.cleanup_stats(db, max_records)
         logging.info("Analytics cleanup deleted %s records.", rowcount)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'bottle-fdsend',
         'bitarray',
         'librarian',
+        'squery-pg'
     ],
     dependency_links=[		
         'git+ssh://git@github.com/Outernet-Project/librarian.git#egg=librarian-4.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import datetime
 from collections import namedtuple
 
 import pytest
-import psycopg2
 
 import helpers as helpers_mod
 from squery_pg.pytest_fixtures import *
@@ -41,7 +40,7 @@ def database_config():
     """
     return {
         'databases': [
-            {'name': 'analytics',
+            {'name': 'librarian',
              'migrations': 'librarian_analytics.migrations.analytics'}
         ],
         'conf': {},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import datetime
 from collections import namedtuple
 
 import pytest
+import psycopg2
 
 import helpers as helpers_mod
 from squery_pg.pytest_fixtures import *
@@ -40,8 +41,15 @@ def database_config():
     """
     return {
         'databases': [
-            {'name': 'librarian',
-             'migrations': 'librarian_analytics.migrations.analytics'}
+            {
+                'name': 'librarian',
+                'database_sets': [
+                    {
+                        'name': 'analytics',
+                        'migrations': 'librarian_analytics.migrations.analytics',
+                    }
+                ],
+            }
         ],
         'conf': {},
     }

--- a/tests/integration/test_helpers_integration.py
+++ b/tests/integration/test_helpers_integration.py
@@ -13,14 +13,14 @@ from librarian_analytics import helpers as mod
 @pytest.fixture
 def populated_database(random_dataset, databases):
     test_data = list(random_dataset())
-    databases.load_fixtures('analytics', 'stats', [d.row for d in test_data])
+    databases.load_fixtures('librarian', 'stats', [d.row for d in test_data])
     return test_data, databases
 
 
 @pytest.fixture
 def sorted_database(random_dataset, databases):
     test_data = sorted(list(random_dataset()), key=lambda x: x.timestamp)
-    databases.load_fixtures('analytics', 'stats', [d.row for d in test_data])
+    databases.load_fixtures('librarian', 'stats', [d.row for d in test_data])
     return test_data, databases
 
 

--- a/tests/integration/test_helpers_integration.py
+++ b/tests/integration/test_helpers_integration.py
@@ -29,7 +29,7 @@ def sorted_database(random_dataset, databases):
 
 def test_get_stats(populated_database):
     test_data, databases = populated_database
-    stats = mod.get_stats(databases.analytics, limit=None)
+    stats = mod.get_stats(databases.librarian, limit=None)
     raw_payload = stats[0]['payload']
     payload = bytes(raw_payload)
     assert isinstance(raw_payload, types.BufferType)
@@ -39,8 +39,8 @@ def test_get_stats(populated_database):
 
 def test_get_stats_limited_ordering(populated_database):
     test_data, databases = populated_database
-    all_stats = mod.get_stats(databases.analytics, limit=None)
-    oldest_two_stats = mod.get_stats(databases.analytics, limit=2)
+    all_stats = mod.get_stats(databases.librarian, limit=None)
+    oldest_two_stats = mod.get_stats(databases.librarian, limit=2)
     assert all_stats[0]['time'] == oldest_two_stats[0]['time']
     assert all_stats[1]['time'] == oldest_two_stats[1]['time']
     assert oldest_two_stats[0]['time'] < oldest_two_stats[1]['time']
@@ -51,28 +51,28 @@ def test_save_stats(random_datapoint, databases):
         'time': random_datapoint.timestamp,
         'payload': random_datapoint.payload
     }
-    mod.save_stats(databases.analytics, data)
-    stats = mod.get_stats(databases.analytics, limit=None)
+    mod.save_stats(databases.librarian, data)
+    stats = mod.get_stats(databases.librarian, limit=None)
     assert len(stats) == 1
     assert bytes(stats[0]['payload']) == random_datapoint.payload
 
 
 def test_clear_transmitted(populated_database):
     test_data, databases = populated_database
-    stats = mod.get_stats(databases.analytics, limit=None)
+    stats = mod.get_stats(databases.librarian, limit=None)
     # We want to set one item aside to prevent it from being cleared
     first = stats.pop(0)
     ids = [s['id'] for s in stats]
-    mod.clear_transmitted(databases.analytics, ids)
-    stats = mod.get_stats(databases.analytics, limit=None)
+    mod.clear_transmitted(databases.librarian, ids)
+    stats = mod.get_stats(databases.librarian, limit=None)
     assert len(stats) == 1
     assert stats[0]['id'] == first['id']
 
 
 def test_clear_transmitted_with_no_ids(populated_database):
     test_data, databases = populated_database
-    mod.clear_transmitted(databases.analytics, [])
-    stats = mod.get_stats(databases.analytics, len(test_data))
+    mod.clear_transmitted(databases.librarian, [])
+    stats = mod.get_stats(databases.librarian, len(test_data))
     assert len(stats) == len(test_data)  # original number of items
 
 
@@ -80,13 +80,13 @@ def test_get_stats_bitstream(populated_database):
     test_data, databases = populated_database
     sorted_data = sorted(test_data, key=lambda x: x.timestamp)
     expected_stream = b''.join(bytes(d.payload) for d in sorted_data)
-    ids, bitstream = mod.get_stats_bitstream(databases.analytics, limit=None)
+    ids, bitstream = mod.get_stats_bitstream(databases.librarian, limit=None)
     assert len(list(ids)) == len(test_data)
     assert bitstream == expected_stream
 
 
 def test_get_stats_bitstream_empty_database(databases):
-    ids, bitstream = mod.get_stats_bitstream(databases.analytics, limit=None)
+    ids, bitstream = mod.get_stats_bitstream(databases.librarian, limit=None)
     assert len(list(ids)) == 0
     assert bitstream == b''
 
@@ -94,9 +94,9 @@ def test_get_stats_bitstream_empty_database(databases):
 def test_cleanup_stats(sorted_database):
     max_records = 2
     test_data, databases = sorted_database
-    stats_before = mod.get_stats(databases.analytics, limit=None)
-    rowcount = mod.cleanup_stats(databases.analytics, max_records=max_records)
-    stats_after = mod.get_stats(databases.analytics, limit=None)
+    stats_before = mod.get_stats(databases.librarian, limit=None)
+    rowcount = mod.cleanup_stats(databases.librarian, max_records=max_records)
+    stats_after = mod.get_stats(databases.librarian, limit=None)
     assert len(stats_after) == max_records
     assert rowcount == len(test_data) - max_records
     # make sure the stats found after the cleanup are the stats that were the
@@ -133,7 +133,7 @@ def test_get_payload(random_path, populated_database):
     test_data, databases = populated_database
     sorted_data = sorted(test_data, key=lambda x: x.timestamp)
     expected_stream = b''.join(bytes(d.payload) for d in sorted_data)
-    ids, payload = mod.get_payload(databases.analytics,
+    ids, payload = mod.get_payload(databases.librarian,
                                    random_path,
                                    limit=None)
     assert len(list(ids)) == len(test_data)
@@ -141,7 +141,7 @@ def test_get_payload(random_path, populated_database):
 
 
 def test_get_payload_empty(random_path, databases):
-    ids, payload = mod.get_payload(databases.analytics,
+    ids, payload = mod.get_payload(databases.librarian,
                                    random_path,
                                    limit=None)
     assert ids == []


### PR DESCRIPTION
This PR is to make analytics use the database common to all librarian components, i.e `librarian` , instead of creating a separate one for itself.